### PR TITLE
Show violations in cs script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "phpstan/phpstan-strict-rules": "^1.5"
     },
     "scripts": {
-        "cs": "php-cs-fixer fix --allow-risky=yes --dry-run",
+        "cs": "php-cs-fixer fix --allow-risky=yes --dry-run --diff",
         "cs:fix": "php-cs-fixer fix --allow-risky=yes",
         "stan": "phpstan analyse --memory-limit 4G",
         "unit": "phpunit --testsuite=Unit",


### PR DESCRIPTION
I don't see the problem.

e.g. https://github.com/PrinsFrank/ADRL-Parser/actions/runs/8474631670/job/23221380958